### PR TITLE
#167203226 Built the REST endpoint to CANCEL TRIPS

### DIFF
--- a/src/controllers/trip.controller.js
+++ b/src/controllers/trip.controller.js
@@ -73,5 +73,36 @@ export default {
       });
   },
 
+  cancel: async (req, res) => {
+    const { trip_id } = req.body;
+
+    await Trips.cancel(trip_id)
+      .then((result) => {
+        if (!result) {
+          return res.status(404)
+            .json({
+              status: 'error',
+              error: 'Trip does not exist',
+            });
+        }
+        return res.status(200)
+          .json({
+            status: 'success',
+            data: {
+              message: 'Trip cancelled successfully',
+            },
+          });
+      })
+      .catch((err) => {
+        logger.error(err);
+        return res.status(500).json({
+          status: 'error',
+          error: {
+            message: err,
+          },
+        });
+      });
+  },
+
 
 };

--- a/src/db/queries.db.js
+++ b/src/db/queries.db.js
@@ -256,6 +256,22 @@ const DBQueries = {
     }
   },
 
+  /**
+   * Cancel a trip
+   */
+  async cancelTrip(trip_id) {
+    const text = 'UPDATE trips SET status = $1 WHERE id = $2';
+    const values = ['cancelled', trip_id];
+
+    try {
+      const res = await pool.query(text, values);
+      return res.rowCount >= 1;
+    } catch (err) {
+      logger.error(err.stack);
+      return err;
+    }
+  },
+
 };
 
 export default DBQueries;

--- a/src/middlewares/validator.js
+++ b/src/middlewares/validator.js
@@ -80,4 +80,33 @@ export default {
     return next();
   },
 
+  checkId: (req, res, next) => {
+    const errors = [];
+
+    const { tripId, bookingId } = req.params;
+
+    if (req.path.includes('trips')) {
+      errors.push(...checkPatternedFields('Trip ID', tripId, numberRegex));
+    } else {
+      errors.push(...checkPatternedFields('Booking ID', bookingId, numberRegex));
+    }
+
+    if (errors.length) {
+      return res.status(400).json({
+        status: 'error',
+        error: errors,
+      });
+    }
+
+    if (typeof tripId !== 'undefined') {
+      req.body.trip_id = tripId;
+    }
+
+    if (typeof bookingId !== 'undefined') {
+      req.body.bookingId = bookingId;
+    }
+
+    return next();
+  },
+
 };

--- a/src/models/trip.model.js
+++ b/src/models/trip.model.js
@@ -23,4 +23,14 @@ export default {
     }
   }),
 
+  /* Cancel a trip */
+  cancel: trip_id => new Promise((resolve, reject) => {
+    try {
+      const result = db.cancelTrip(trip_id);
+      resolve(result);
+    } catch (err) {
+      reject(err);
+    }
+  }),
+
 };

--- a/src/routes/index.routes.js
+++ b/src/routes/index.routes.js
@@ -21,6 +21,8 @@ router.get('/buses', Authenticator.checkToken, BusController.findAll);
 router.post('/trips', Authenticator.checkToken, Authenticator.isAdmin,
   Validator.trip, TripController.create);
 router.get('/trips', TripController.findAll);
+router.patch('/trips/:tripId', Authenticator.checkToken,
+  Authenticator.isAdmin, Validator.checkId, TripController.cancel);
 
 
 export default router;

--- a/src/test/main.js
+++ b/src/test/main.js
@@ -462,4 +462,64 @@ describe('TESTING THE TRIPS ENDPOINTS', () => {
       });
   });
 
+  it('Admin can cancel trip', (done) => {
+
+    const tripId = 1;
+
+    const cValue = "token=" + tokenAdmin;
+
+    chai.request(server)
+      .patch(`/api/v1/trips/${tripId}`)
+      .set('Cookie', cValue)
+      .end((err, res) => {
+        res.should.have.status(200);
+        done();
+      });
+  });
+
+  it('Admin cannot cancel a nonexistent trip', (done) => {
+
+    const tripId = 99;
+
+    const cValue = "token=" + tokenAdmin;
+
+    chai.request(server)
+      .patch(`/api/v1/trips/${tripId}`)
+      .set('Cookie', cValue)
+      .end((err, res) => {
+        res.should.have.status(404);
+        done();
+      });
+  });
+
+  it('trip to be cancelled must be valid', (done) => {
+
+    const tripId = '099';
+
+    const cValue = "token=" + tokenAdmin;
+
+    chai.request(server)
+      .patch(`/api/v1/trips/${tripId}`)
+      .set('Cookie', cValue)
+      .end((err, res) => {
+        res.should.have.status(400);
+        done();
+      });
+  });
+
+  it('only Admin can cancel trips', (done) => {
+
+    const tripId = 2;
+
+    const cValue = "token=" + tokenUser;
+
+    chai.request(server)
+      .patch(`/api/v1/trips/${tripId}`)
+      .set('Cookie', cValue)
+      .end((err, res) => {
+        res.should.have.status(401);
+        done();
+      });
+  });
+
 });


### PR DESCRIPTION
#### What does this PR do?
This feature allows an admin to cancel a trip i.e. set status of trip from 'active' to 'cancelled'

#### How should this be manually tested?
Hit the endpoint below with any REST API client:
`PATCH /api/v1/trips/<trip_id>
`
#### Any background context you want to provide?
```
Only admins have the power to cancel the trip and the trip_id
must be existing for it to be cancelled.
```

#### What are the relevant pivotal tracker stories?
[ #167203226](https://www.pivotaltracker.com/story/show/167203226)